### PR TITLE
PyTest integration improvements: automatically register marker and rename `vcr_cassette` fixture

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
         "six>=1.5",
         "yarl",
         "pytest",
-        "urllib3<2",  # mparent(2025-05-22): 2+ breaks this libray
+        "urllib3<2",  # mparent(2025-05-22): 2+ breaks this library.
     ],
     extras_require={
         "development": ["snowflake-connector-python[pandas]"],

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ def get_snowflake_vcrpy_packages():
 
 setup(
     name="snowflake-vcrpy",
-    version="0.1.0",
+    version="0.1.2",
     license="Apache License, Version 2.0",
     description="Snowflake version of VCR.py to record and replay tests based on snowflake-connector-python",
     packages=get_snowflake_vcrpy_packages(),
@@ -21,6 +21,7 @@ setup(
         "six>=1.5",
         "yarl",
         "pytest",
+        "urllib3<2",  # mparent(2025-05-22): 2+ breaks this libray
     ],
     extras_require={
         "development": ["snowflake-connector-python[pandas]"],

--- a/src/snowflake/vcrpy/snowflake_vcrpy_pytest_plugin.py
+++ b/src/snowflake/vcrpy/snowflake_vcrpy_pytest_plugin.py
@@ -61,6 +61,12 @@ def _process_response_recording(response):
     return response
 
 
+def pytest_configure(config):
+    config.addinivalue_line(
+        "markers", "snowflake_vcr: Mark the test as using Snowflake VCR."
+    )
+
+
 @pytest.fixture(autouse=True)
 def _snowflake_vcr_marker(request):
     snowflake_record_mode = request.config.getoption(

--- a/src/snowflake/vcrpy/snowflake_vcrpy_pytest_plugin.py
+++ b/src/snowflake/vcrpy/snowflake_vcrpy_pytest_plugin.py
@@ -70,7 +70,7 @@ def _snowflake_vcr_marker(request):
     if snowflake_record_mode == SnowflakeRecordMode.ALL or (
         snowflake_record_mode == SnowflakeRecordMode.ANNOTATED and marker
     ):
-        request.getfixturevalue("vcr_cassette")
+        request.getfixturevalue("snowflake_vcr_cassette")
     else:
         return
 
@@ -116,7 +116,7 @@ def pytest_addoption(parser):
 
 
 @pytest.fixture
-def vcr_cassette(request, snowflake_vcr, snowflake_vcr_cassette_name):
+def snowflake_vcr_cassette(request, snowflake_vcr, snowflake_vcr_cassette_name):
     kwargs = {}
     _update_kwargs(request, kwargs)
     with snowflake_vcr.use_cassette(snowflake_vcr_cassette_name, **kwargs) as cassette:


### PR DESCRIPTION
## What does this PR do?

This applies 2 "quality of life" improvements for integration with `pytest` and the `pytest-vcr` plugin:

1. Automatically register the `snowflake_vcr` marker, instead of requiring developers to add it to their own `pytest.ini` file:
    - Follows the [best-practice approach from PyTest documentation](https://docs.pytest.org/en/latest/example/markers.html#custom-marker-and-command-line-option-to-control-test-runs). 
    - Avoids this PyTest startup error: 
        ```pytest.PytestUnknownMarkWarning: Unknown pytest.mark.snowflake_vcr - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html```

2. Rename the `vcr_cassette` fixture to `snowflake_vcr_cassette`:
    - This better matches the `snowflake_` fixture name prefix in this library
    - Avoids conflict with the standard `vcr_cassette` fixture used by [pytest-vcr](https://pytest-vcr.readthedocs.io/en/latest/) plugin.

## How was this tested?

I have been using this branch successfully for my own development, and am able to record Snowflake interactions to VCR cassettes, side-by-side with a "standard" VCR install using the `pytest-vcr` plugin.